### PR TITLE
Added MIT License to distribution

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Blacks In Technology
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ TODO: Write credits
 
 ## License
 
-TODO: Write license
+BiT Slack Bot Project is using the [Apache 2.0 License](LICENSE.txt).


### PR DESCRIPTION
- LICENSE.txt - A copy of the MIT License applied to this project

Updates BlacksInTechnologyOrg/bit-slack-greeting-bot#10

Furthermore, this license was selected because it's a simple license that allows people to use the code as they wish without worry about reprisal from Blacks In Technology. It also doesn't make the users pick a particular license, like the GPL.

Here's another developer's take on [why he chooses the MIT License](https://ttmm.io/tech/why-the-mit-license/) in greater detail.